### PR TITLE
Update README.md

### DIFF
--- a/upscale_models/README.md
+++ b/upscale_models/README.md
@@ -8,4 +8,4 @@ Here is an example:
 
 You can load this image in [ComfyUI](https://github.com/comfyanonymous/ComfyUI) to get the workflow.
 
-If you are looking for upscale models to use you can find some on [The Upscale Wiki](https://upscale.wiki/wiki/Model_Database)
+If you are looking for upscale models to use you can find some on [OpenModelDB](https://openmodeldb.info/)


### PR DESCRIPTION
The link to "The Upscale WiKi" is old. The owners of that site have moved their content to OpenModelDB.