### PR TITLE
Add section header to lora formats of flux canny and depth

### DIFF
--- a/flux/README.md
+++ b/flux/README.md
@@ -95,6 +95,8 @@ Here is an example for the full canny model:
 
 ![Example](flux_canny_model_example.png)
 
+#### Canny and Depth Lora Format
+
 They are also published in lora format that can be applied to the flux dev model: [flux1-canny-dev-lora.safetensors](https://huggingface.co/black-forest-labs/FLUX.1-Canny-dev-lora) and [flux1-depth-dev-lora.safetensors](https://huggingface.co/black-forest-labs/FLUX.1-Depth-dev-lora), put them in your ComfyUI/models/loras/ folder
 
 Here is an example for the depth lora.


### PR DESCRIPTION
### Problem

- The template workflows link to the start of the Flux canny and depth section.
- One of the template workflows is for the lora format of the depth flux model
- When trying that template, the user goes to the top of the section and thinks they need the flux depth dev model, instead of scrolling down and seeing that they only need to download the lora format and change the value in the LoraLoaderModelOnly node.

### Proposed Solution

- Create a section header above the lora format section
- There's then a hyperlinkable anchor
- The flux depth lora format template workflow can be adjusted to link directly to that section, preventing this common user headache